### PR TITLE
Add rackIdSupplier and funnel into KafkaPartitionSplitReader

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -98,6 +98,8 @@ public class KafkaSource<OUT>
     private final KafkaRecordDeserializationSchema<OUT> deserializationSchema;
     // The configurations.
     private final Properties props;
+    // Client rackId callback
+    private final Supplier<String> rackIdSupplier;
 
     KafkaSource(
             KafkaSubscriber subscriber,
@@ -105,13 +107,15 @@ public class KafkaSource<OUT>
             @Nullable OffsetsInitializer stoppingOffsetsInitializer,
             Boundedness boundedness,
             KafkaRecordDeserializationSchema<OUT> deserializationSchema,
-            Properties props) {
+            Properties props,
+            Supplier<String> rackIdSupplier) {
         this.subscriber = subscriber;
         this.startingOffsetsInitializer = startingOffsetsInitializer;
         this.stoppingOffsetsInitializer = stoppingOffsetsInitializer;
         this.boundedness = boundedness;
         this.deserializationSchema = deserializationSchema;
         this.props = props;
+        this.rackIdSupplier = rackIdSupplier;
     }
 
     /**
@@ -157,7 +161,8 @@ public class KafkaSource<OUT>
                 new KafkaSourceReaderMetrics(readerContext.metricGroup());
 
         Supplier<KafkaPartitionSplitReader> splitReaderSupplier =
-                () -> new KafkaPartitionSplitReader(props, readerContext, kafkaSourceReaderMetrics);
+                () -> new KafkaPartitionSplitReader(props, readerContext, kafkaSourceReaderMetrics,
+                        rackIdSupplier);
         KafkaRecordEmitter<OUT> recordEmitter = new KafkaRecordEmitter<>(deserializationSchema);
 
         return new KafkaSourceReader<>(

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -161,8 +161,9 @@ public class KafkaSource<OUT>
                 new KafkaSourceReaderMetrics(readerContext.metricGroup());
 
         Supplier<KafkaPartitionSplitReader> splitReaderSupplier =
-                () -> new KafkaPartitionSplitReader(props, readerContext, kafkaSourceReaderMetrics,
-                        rackIdSupplier);
+                () ->
+                        new KafkaPartitionSplitReader(
+                                props, readerContext, kafkaSourceReaderMetrics, rackIdSupplier);
         KafkaRecordEmitter<OUT> recordEmitter = new KafkaRecordEmitter<>(deserializationSchema);
 
         return new KafkaSourceReader<>(

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -361,7 +361,7 @@ public class KafkaSourceBuilder<OUT> {
     }
 
     /**
-     * Set the clientRackId supplier to be passed down to the KafkaPartitionSplitReader
+     * Set the clientRackId supplier to be passed down to the KafkaPartitionSplitReader.
      *
      * @param rackIdCallback callback to provide Kafka consumer client.rack
      * @return this KafkaSourceBuilder

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -80,6 +81,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  *     .setTopics(Arrays.asList(TOPIC1, TOPIC2))
  *     .setDeserializer(KafkaRecordDeserializationSchema.valueOnly(StringDeserializer.class))
  *     .setUnbounded(OffsetsInitializer.latest())
+ *     .setRackId(() -> MY_RACK_ID)
  *     .build();
  * }</pre>
  *
@@ -100,6 +102,8 @@ public class KafkaSourceBuilder<OUT> {
     private KafkaRecordDeserializationSchema<OUT> deserializationSchema;
     // The configurations.
     protected Properties props;
+    // Client rackId supplier
+    private Supplier<String> rackIdSupplier;
 
     KafkaSourceBuilder() {
         this.subscriber = null;
@@ -108,6 +112,7 @@ public class KafkaSourceBuilder<OUT> {
         this.boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
         this.deserializationSchema = null;
         this.props = new Properties();
+        this.rackIdSupplier = null;
     }
 
     /**
@@ -356,6 +361,17 @@ public class KafkaSourceBuilder<OUT> {
     }
 
     /**
+     * Set the clientRackId supplier to be passed down to the KafkaPartitionSplitReader
+     *
+     * @param rackIdCallback callback to provide Kafka consumer client.rack
+     * @return this KafkaSourceBuilder
+     */
+    public KafkaSourceBuilder<OUT> setRackId(Supplier<String> rackIdCallback) {
+        this.rackIdSupplier = rackIdCallback;
+        return this;
+    }
+
+    /**
      * Set an arbitrary property for the KafkaSource and KafkaConsumer. The valid keys can be found
      * in {@link ConsumerConfig} and {@link KafkaSourceOptions}.
      *
@@ -422,7 +438,8 @@ public class KafkaSourceBuilder<OUT> {
                 stoppingOffsetsInitializer,
                 boundedness,
                 deserializationSchema,
-                props);
+                props,
+                rackIdSupplier);
     }
 
     // ------------- private helpers  --------------

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -79,12 +79,14 @@ public class KafkaPartitionSplitReader
     public KafkaPartitionSplitReader(
             Properties props,
             SourceReaderContext context,
-            KafkaSourceReaderMetrics kafkaSourceReaderMetrics) {
+            KafkaSourceReaderMetrics kafkaSourceReaderMetrics,
+            Supplier<String> rackIdSupplier) {
         this.subtaskId = context.getIndexOfSubtask();
         this.kafkaSourceReaderMetrics = kafkaSourceReaderMetrics;
         Properties consumerProps = new Properties();
         consumerProps.putAll(props);
         consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, createConsumerClientId(props));
+        setConsumerClientRack(consumerProps, rackIdSupplier);
         this.consumer = new KafkaConsumer<>(consumerProps);
         this.stoppingOffsets = new HashMap<>();
         this.groupId = consumerProps.getProperty(ConsumerConfig.GROUP_ID_CONFIG);
@@ -255,6 +257,12 @@ public class KafkaPartitionSplitReader
     }
 
     // --------------- private helper method ----------------------
+
+    private void setConsumerClientRack(Properties consumerProps, Supplier<String> rackIdSupplier) {
+        if (rackIdSupplier != null) {
+            consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, rackIdSupplier.get());
+        }
+    }
 
     private void parseStartingOffsets(
             KafkaPartitionSplit split,

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -79,6 +79,13 @@ public class KafkaPartitionSplitReader
     public KafkaPartitionSplitReader(
             Properties props,
             SourceReaderContext context,
+            KafkaSourceReaderMetrics kafkaSourceReaderMetrics) {
+        this(props, context, kafkaSourceReaderMetrics, () -> null);
+    }
+
+    public KafkaPartitionSplitReader(
+            Properties props,
+            SourceReaderContext context,
             KafkaSourceReaderMetrics kafkaSourceReaderMetrics,
             Supplier<String> rackIdSupplier) {
         this.subtaskId = context.getIndexOfSubtask();
@@ -260,7 +267,10 @@ public class KafkaPartitionSplitReader
 
     private void setConsumerClientRack(Properties consumerProps, Supplier<String> rackIdSupplier) {
         if (rackIdSupplier != null) {
-            consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, rackIdSupplier.get());
+            String rackId = rackIdSupplier.get();
+            if (rackId != null) {
+                consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, rackId);
+            }
         }
     }
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -265,10 +265,10 @@ public class KafkaPartitionSplitReader
 
     // --------------- private helper method ----------------------
 
-    private void setConsumerClientRack(Properties consumerProps, Supplier<String> rackIdSupplier) {
+    void setConsumerClientRack(Properties consumerProps, Supplier<String> rackIdSupplier) {
         if (rackIdSupplier != null) {
             String rackId = rackIdSupplier.get();
-            if (rackId != null) {
+            if (rackId != null && !rackId.isEmpty()) {
                 consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, rackId);
             }
         }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -74,6 +74,7 @@ public class KafkaPartitionSplitReaderTest {
     private static final String TOPIC1 = "topic1";
     private static final String TOPIC2 = "topic2";
     private static final String TOPIC3 = "topic3";
+    private static final String CLIENT_RACK = "use1-az1";
 
     private static Map<Integer, Map<String, KafkaPartitionSplit>> splitsByOwners;
     private static Map<TopicPartition, Long> earliestOffsets;
@@ -394,7 +395,8 @@ public class KafkaPartitionSplitReaderTest {
         return new KafkaPartitionSplitReader(
                 props,
                 new TestingReaderContext(new Configuration(), sourceReaderMetricGroup),
-                kafkaSourceReaderMetrics);
+                kafkaSourceReaderMetrics,
+                () -> CLIENT_RACK);
     }
 
     private Map<String, KafkaPartitionSplit> assignSplits(

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -323,10 +323,11 @@ public class KafkaPartitionSplitReaderTest {
     @Test
     public void testConsumerClientRackSupplier() {
         AtomicReference<Boolean> supplierCalled = new AtomicReference<>(false);
+        String rackId = "use-az1";
         Supplier<String> rackIdSupplier =
                 () -> {
                     supplierCalled.set(true);
-                    return "foo";
+                    return rackId;
                 };
         Properties properties = new Properties();
         createReader(
@@ -334,7 +335,7 @@ public class KafkaPartitionSplitReaderTest {
                 UnregisteredMetricsGroup.createSourceReaderMetricGroup(),
                 rackIdSupplier);
         assertThat(supplierCalled.get()).isEqualTo(true);
-        assertThat("foo".equals(properties.getProperty(ConsumerConfig.CLIENT_RACK_CONFIG)));
+        assertThat(rackId.equals(properties.getProperty(ConsumerConfig.CLIENT_RACK_CONFIG)));
     }
 
     // ------------------

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -323,12 +323,18 @@ public class KafkaPartitionSplitReaderTest {
     @Test
     public void testConsumerClientRackSupplier() {
         AtomicReference<Boolean> supplierCalled = new AtomicReference<>(false);
-        Supplier<String> rackIdSupplier = () -> {
-            supplierCalled.set(true);
-            return null;
-        };
-        createReader(new Properties(), UnregisteredMetricsGroup.createSourceReaderMetricGroup(), rackIdSupplier);
+        Supplier<String> rackIdSupplier =
+                () -> {
+                    supplierCalled.set(true);
+                    return "foo";
+                };
+        Properties properties = new Properties();
+        createReader(
+                properties,
+                UnregisteredMetricsGroup.createSourceReaderMetricGroup(),
+                rackIdSupplier);
         assertThat(supplierCalled.get()).isEqualTo(true);
+        assertThat("foo".equals(properties.getProperty(ConsumerConfig.CLIENT_RACK_CONFIG)));
     }
 
     // ------------------
@@ -394,8 +400,7 @@ public class KafkaPartitionSplitReaderTest {
     }
 
     private KafkaPartitionSplitReader createReader(
-            Properties additionalProperties,
-            SourceReaderMetricGroup sourceReaderMetricGroup) {
+            Properties additionalProperties, SourceReaderMetricGroup sourceReaderMetricGroup) {
         return createReader(additionalProperties, sourceReaderMetricGroup, () -> null);
     }
 


### PR DESCRIPTION
First pass at client.rack supplier for the `KafkaPartitionSplitReader`